### PR TITLE
prefer `execsyncs` as it uses node 0.11.x’s built in exec sync if availa...

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var fs = require('fs');
-var execSync = require('execSync').exec;
+var execSync = require('execsyncs');
 var rimraf = require('rimraf');
 
 var RAMDISK_BYTES = 2 * 1024 * 1024 * 1024;
@@ -23,12 +23,11 @@ function ramdiskExists() {
 
 function runCommand(command) {
   console.log("ember-cli-ramdisk: " + command);
-
-  var result = execSync(command);
-  if (result.code !== 0) {
-    throw new Error("ember-cli-ramdisk: error running command(" + result.code + "): " + result.stdout);
+  try {
+    return  execSync(command).toString();
+  } catch(e) {
+    throw new Error("ember-cli-ramdisk: error running command(" + command + "): " + e.message);
   }
-  return result.stdout;
 }
 
 function removeOldTmpDirectory(projectTmpPath) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Alex Matchneer <machty@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "execSync": "^1.0.2",
+    "execsyncs": "^0.1.1",
     "rimraf": "^2.2.8"
   },
   "repository": {


### PR DESCRIPTION
...ble.
- [x] confirm stability

seems to work great on 0.10.33 and 0.11.14
