### PR TITLE
added environment variable for disabling ramdisk

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,10 @@ module.exports = {
   name: 'ember-cli-ramdisk',
   included: function(app) {
 
+    if (process.env.RAMDISK_DISABLED) {
+      return;
+    }
+
     var projectTmpPath = app.project.root + "/tmp";
 
     if (process.platform !== 'darwin' && process.platform !== 'linux') {


### PR DESCRIPTION
some users on our team use the ramdisk, some do not. In addition, ramdisk has been breaking on our linux platforms: 3.14-1-amd64 #1 SMP Debian 3.14.7-1 (2014-06-16) x86_64

this allows adding the following line to `.profile` to disable ramdisk
`export RAMDISK_DISABLED=true`
