### PR TITLE
Use nodes child_process.execSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var fs = require('fs');
-var execSync = require('execsyncs');
 var rimraf = require('rimraf');
+var child_process = require('child_process');
 
 var RAMDISK_BYTES = 2 * 1024 * 1024 * 1024;
 var BLOCK_SIZE = 512;
@@ -24,7 +24,7 @@ function ramdiskExists() {
 function runCommand(command) {
   console.log("ember-cli-ramdisk: " + command);
   try {
-    return  execSync(command).toString();
+    return  child_process.execSync(command).toString();
   } catch(e) {
     throw new Error("ember-cli-ramdisk: error running command(" + command + "): " + e.message);
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "author": "Alex Matchneer <machty@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "execsyncs": "^0.1.1",
     "rimraf": "^2.2.8"
   },
   "repository": {


### PR DESCRIPTION
Had some trouble to install `execsyncs`, so I replaced it with nodes `child_process.execSync`.
